### PR TITLE
Stop sharing Emitter

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,6 @@
 var _ = require('./vendor/lodash-custom.js');
 var Section = require('./section.js');
 var Emitter = require('emitter');
-var eventPipe = new Emitter;
 
 /**
  * Creates a new SideComments instance.
@@ -19,7 +18,7 @@ var eventPipe = new Emitter;
 function SideComments( el, currentUser, existingComments ) {
   this.$el = $(el);
   this.$body = $('body');
-  this.eventPipe = eventPipe;
+  this.eventPipe = new Emitter;
 
   this.currentUser = _.clone(currentUser) || null;
   this.existingComments = _.cloneDeep(existingComments) || [];


### PR DESCRIPTION
It's currently not possible to use multiple instances of SideComments on a page due to a shared Emitter. This creates a new emitter per SideComments instance to allow multiple independent instances per page to function.
