### PR TITLE
frontend protection against XXS attack

### DIFF
--- a/release/side-comments.js
+++ b/release/side-comments.js
@@ -748,7 +748,7 @@ Section.prototype.postComment = function() {
   	  commentBody = $commentBox.val(),
   	  comment = {
 	  	sectionId: this.id,
-	  	comment: commentBody,
+	  	comment: commentBody.split(/<\s*[^>]*>/g).join(''),
 	  	authorAvatarUrl: this.currentUser.avatarUrl,
 	  	authorName: this.currentUser.name,
 	  	authorId: this.currentUser.id,


### PR DESCRIPTION
Removes possibility of same page scripting through comments, and doesn't allow other HTML tags as well. The same be must be done at back-end(at server, before storing comments in database) also.